### PR TITLE
fix(coercion): fix non-value boolean flags

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -56,7 +56,7 @@ const defaultValue = (type?: "boolean" | "string" | "array") => {
 
 const coerce = (value?: string, type?: "string" | "boolean" | "array") => {
   if (type === "string") return value;
-  if (type === "boolean") return !!value;
+  if (type === "boolean") return value === undefined ? true : value === 'true';
 
   if (!value) return value;
   if (value.length > 3 && BOOL_RE.test(value)) return value === "true";

--- a/test/flags.test.ts
+++ b/test/flags.test.ts
@@ -257,3 +257,24 @@ describe("special cases", () => {
     expect(result).toEqual(output);
   });
 });
+
+describe("boolean flags", () => {
+  it("should handle long-form boolean flags correctly", () => {
+    const input = ["--add"];
+    const opts = {
+      boolean: ['add']
+    };
+    const output = { _: [], add: true };
+    expect(parse(input, opts)).toEqual(output);
+  });
+
+  it("should handle alias boolean flags correctly", () => {
+    const input = ["-a"];
+    const opts = {
+      boolean: ['add'],
+      alias: { a: 'add' }
+    };
+    const output = { _: [], add: true };
+    expect(parse(input, opts)).toEqual(output);
+  });
+});


### PR DESCRIPTION
### About

This pr fixes a bug I found which always set the long-form non-value boolean flags to `false`, i.e. `mycli --mybool` will output ` { _: [], mybool: false }`

###### Here's a [repro](https://stackblitz.com/edit/stackblitz-starters-jaa87t5h?file=index.js) of the bug
### Changes

- Modified the operation on the `coerce` function to properly set long-form non-value _(undefined)_ boolean flags to `true`
- Added a couple of tests to verify the integrity of the change

### Checks
- [x] All tests pass 