### PR TITLE
Fix coerce() returning NaN for non-numeric digit-starting strings

### DIFF
--- a/.changeset/fix-coerce-nan.md
+++ b/.changeset/fix-coerce-nan.md
@@ -1,0 +1,5 @@
+---
+"@bomb.sh/args": patch
+---
+
+Fix coerce() returning NaN for non-numeric digit-starting strings

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,8 +61,10 @@ const coerce = (value?: string, type?: "string" | "boolean" | "array") => {
 	if (!value) return value;
 	if (value.length > 3 && BOOL_RE.test(value)) return value === "true";
 	if (value.length > 2 && QUOTED_RE.test(value)) return value.slice(1, -1);
-	if ((value[0] === "." && /\d/.test(value[1])) || /\d/.test(value[0]))
-		return Number(value);
+	if ((value[0] === "." && /\d/.test(value[1])) || /\d/.test(value[0])) {
+		const n = Number(value);
+		if (!isNaN(n)) return n;
+	}
 	return value;
 };
 

--- a/test/flags.test.ts
+++ b/test/flags.test.ts
@@ -258,6 +258,26 @@ describe("special cases", () => {
   });
 });
 
+describe("coerce NaN guard", () => {
+  it("version-like string as positional is kept as string", () => {
+    expect(parse(["3.7.1"])).toEqual({ _: ["3.7.1"] });
+  });
+
+  it("digit-prefixed non-numeric string as positional is kept as string", () => {
+    expect(parse(["1abc"])).toEqual({ _: ["1abc"] });
+  });
+
+  it("version-like string as flag value is kept as string", () => {
+    expect(parse(["--version", "3.7.1"])).toEqual({ _: [], version: "3.7.1" });
+  });
+
+  it("valid numbers still coerce correctly", () => {
+    expect(parse(["42"])).toEqual({ _: [42] });
+    expect(parse([".5"])).toEqual({ _: [0.5] });
+    expect(parse(["3.14"])).toEqual({ _: [3.14] });
+  });
+});
+
 describe("boolean flags", () => {
   it("should handle long-form boolean flags correctly", () => {
     const input = ["--add"];


### PR DESCRIPTION
This PR:

- Fixes `coerce()`: it was converting any digit-starting string to `Number(value)`, even when the result is `NaN` (e.g. `"3.7.1"`, `"1abc"`)
- Added an `isNaN` guard so invalid conversions fall back to the original string

For example:
- `parse(["3.7.1"])` → `{ _: ["3.7.1"] }` (was `{ _: [NaN] }`)
- `parse(["1abc"])` → `{ _: ["1abc"] }` (was `{ _: [NaN] }`)
- `parse(["--version", "3.7.1"])` → `{ version: "3.7.1" }` (was `{ version: NaN }`)
- Existing numeric coercion unchanged: `"42"` → `42`, `".5"` → `0.5`, `"3.14"` → `3.14`
